### PR TITLE
대댓글인 경우 한 단계 들여쓰기

### DIFF
--- a/clien.py
+++ b/clien.py
@@ -336,6 +336,8 @@ def show_comment(bbs_title, article_num, article_data, sub_page):
             try:
                 comment = item['comment']
                 username = item['member']['userId']
+                re_comment_sn = item['reCommentSn']
+                comment_sn = item['commentSn']
                 l = comment.replace("\n"," ").split(" ")
                 n = 10
                 lines = [' '.join(l[x:x+n]) for x in range(0, len(l), n)]
@@ -346,10 +348,16 @@ def show_comment(bbs_title, article_num, article_data, sub_page):
                         line = "\""+line
                     if idx==len(lines)-1:
                         line = line+"\""
-                    print("\t"+line.strip())
+                    if re_comment_sn!=comment_sn:
+                        print("\t\t"+line.strip())
+                    else:
+                        print("\t"+line.strip())
                     idx+=1
 
-                print("\t(by "+username+")")
+                if re_comment_sn!=comment_sn:
+                    print("\t\t(by "+username+")")
+                else:
+                    print("\t(by "+username+")")
                 print("")
             except:
                 print("")


### PR DESCRIPTION
클리앙 웹페이지에서 대댓글의 경우 다른 댓글보다 한 단계 들여쓰기가 되어있습니다.

clineBBS에서도 대댓글의 경우 Tab을 추가하여 보여주면 좋을 것 같아서 수정해보았습니다.


감사합니다.